### PR TITLE
Add Dan graphical calculator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Mini-readme: Ignore development artifacts
+# This file tells Git to ignore virtual environments, logs, and compiled artifacts.
+# Structure: patterns for Python caches, virtual environments, and logs.
+__pycache__/
+*.pyc
+*.pyo
+*.log
+.venv/
+venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# graphical-calculator
+# Dan Graphical Calculator
+
+Dan is a green-themed graphical calculator built with Python's standard library.
+The application offers both a Tkinter-based GUI and a command-line mode for quick evaluations.
+
+## Features
+- Safe evaluation of arithmetic expressions (no `eval` usage).
+- Modern green styling with clear on-screen instructions.
+- Keyboard and button input support.
+- Debug-friendly logging to `dan_calculator.log`.
+
+## Prerequisites
+- Python 3.10 or newer with Tkinter support.
+- No external Python packages are required.
+
+## Quick Start
+### Linux / macOS / Raspberry Pi
+```bash
+# Option 1: using setup script
+bash setup_dan_environment.sh
+source .venv/bin/activate
+python dan_graphical_calculator.py
+
+# Option 2: manual steps
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python dan_graphical_calculator.py
+```
+
+### Windows
+```bat
+:: Option 1: using setup script
+setup_dan_environment.bat
+call .venv\Scripts\activate
+python dan_graphical_calculator.py
+
+:: Option 2: manual steps
+python -m venv .venv
+call .venv\Scripts\activate
+python -m pip install --upgrade pip
+python dan_graphical_calculator.py
+```
+
+## Command-Line Evaluation
+Evaluate an expression without launching the GUI:
+```bash
+python dan_graphical_calculator.py --expression "2+2"
+```
+
+## Logs
+Runtime information is stored in `dan_calculator.log` for debugging purposes.
+
+## Usage
+- Click buttons or use the keyboard to enter expressions.
+- Press `=` to compute or `C` to clear.
+- On-screen instructions guide basic usage, so no manual reading is required.
+
+## License
+This project is provided as-is for educational purposes.

--- a/dan_graphical_calculator.py
+++ b/dan_graphical_calculator.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+dan_graphical_calculator.py
+Mini-readme: Provides Dan, a green-themed graphical calculator application.
+Structure:
+    - safe_eval: Safely evaluates arithmetic expressions using Python's AST.
+    - CalculatorApp: Handles GUI creation and user interactions.
+    - main: Parses command-line arguments and launches GUI or CLI evaluation.
+Usage:
+    - python dan_graphical_calculator.py          # Launches GUI
+    - python dan_graphical_calculator.py --expression "2+2"  # CLI evaluation
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import logging
+import operator
+import sys
+import tkinter as tk
+from tkinter import ttk
+
+# Configure logging for both console and file outputs
+logger = logging.getLogger("dan_calculator")
+logger.setLevel(logging.DEBUG)
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+if not logger.handlers:
+    file_handler = logging.FileHandler("dan_calculator.log")
+    file_handler.setFormatter(formatter)
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    logger.addHandler(console_handler)
+
+# Allowed operators for safe evaluation
+_ALLOWED_OPERATORS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Pow: operator.pow,
+    ast.USub: operator.neg,
+}
+
+
+def safe_eval(expression: str) -> float:
+    """Safely evaluate a mathematical expression.
+
+    Args:
+        expression: String containing the expression to evaluate.
+
+    Returns:
+        The numerical result of the expression.
+
+    Raises:
+        ValueError: If the expression contains unsupported operations.
+    """
+
+    def _eval(node: ast.AST) -> float:
+        if isinstance(node, ast.BinOp):
+            op_type = type(node.op)
+            if op_type in _ALLOWED_OPERATORS:
+                left = _eval(node.left)
+                right = _eval(node.right)
+                return _ALLOWED_OPERATORS[op_type](left, right)
+            raise ValueError(f"Operator {op_type} is not allowed")
+        if isinstance(node, ast.UnaryOp):
+            op_type = type(node.op)
+            if op_type in _ALLOWED_OPERATORS:
+                operand = _eval(node.operand)
+                return _ALLOWED_OPERATORS[op_type](operand)
+            raise ValueError(f"Unary operator {op_type} is not allowed")
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return node.value
+        raise ValueError(f"Unsupported expression element: {ast.dump(node)}")
+
+    logger.debug("Evaluating expression: %s", expression)
+    tree = ast.parse(expression, mode="eval")
+    return _eval(tree.body)
+
+
+class CalculatorApp:
+    """Main application class for Dan calculator."""
+
+    def __init__(self) -> None:
+        self.root = tk.Tk()
+        self.root.title("Dan - Green Calculator")
+        self.root.configure(bg="#ccffcc")  # Light green background
+        self.expression_var = tk.StringVar()
+        self._create_widgets()
+        self.root.bind("<Key>", self._on_keypress)
+
+    def _create_widgets(self) -> None:
+        """Create and layout widgets."""
+        style = ttk.Style()
+        style.theme_use("clam")
+        style.configure("Dan.TButton", background="#006400", foreground="white", padding=10, font=("Helvetica", 12))
+        style.map("Dan.TButton", background=[("active", "#228B22")])
+        style.configure("Dan.TLabel", background="#ccffcc", foreground="black", font=("Helvetica", 14))
+        style.configure("Dan.TEntry", fieldbackground="#e0ffe0", foreground="black", font=("Helvetica", 16))
+
+        info = ttk.Label(self.root, text="Welcome to Dan. Use buttons or keyboard; '=' evaluates, 'C' clears.", style="Dan.TLabel")
+        info.grid(row=0, column=0, columnspan=4, pady=(10, 5))
+
+        entry = ttk.Entry(self.root, textvariable=self.expression_var, justify="right", style="Dan.TEntry")
+        entry.grid(row=1, column=0, columnspan=4, padx=10, pady=5, sticky="nsew")
+
+        buttons = [
+            ("7", 2, 0), ("8", 2, 1), ("9", 2, 2), ("/", 2, 3),
+            ("4", 3, 0), ("5", 3, 1), ("6", 3, 2), ("*", 3, 3),
+            ("1", 4, 0), ("2", 4, 1), ("3", 4, 2), ("-", 4, 3),
+            ("0", 5, 0), (".", 5, 1), ("C", 5, 2), ("+", 5, 3),
+            ("=", 6, 0),
+        ]
+
+        for (text, row, col) in buttons:
+            cmd = lambda t=text: self._on_button_press(t)
+            ttk.Button(self.root, text=text, command=cmd, style="Dan.TButton").grid(row=row, column=col, padx=5, pady=5, sticky="nsew")
+
+        # Expand grid cells
+        for i in range(4):
+            self.root.columnconfigure(i, weight=1)
+        for i in range(7):
+            self.root.rowconfigure(i, weight=1)
+
+    def _on_button_press(self, symbol: str) -> None:
+        """Handle button presses."""
+        logger.debug("Button pressed: %s", symbol)
+        if symbol == "C":
+            self._clear()
+        elif symbol == "=":
+            self._evaluate()
+        else:
+            current = self.expression_var.get()
+            self.expression_var.set(current + symbol)
+
+    def _on_keypress(self, event: tk.Event) -> None:
+        """Handle keyboard input."""
+        char = event.char
+        if char in "0123456789.+-*/":
+            self.expression_var.set(self.expression_var.get() + char)
+        elif event.keysym == "Return":
+            self._evaluate()
+        elif event.keysym == "Escape":
+            self._clear()
+
+    def _evaluate(self) -> None:
+        """Evaluate current expression."""
+        expr = self.expression_var.get()
+        try:
+            result = safe_eval(expr)
+            self.expression_var.set(str(result))
+            logger.info("Evaluated: %s = %s", expr, result)
+        except Exception as exc:  # pragma: no cover - GUI feedback
+            logger.exception("Evaluation error for %s", expr)
+            self.expression_var.set("Error")
+
+    def _clear(self) -> None:
+        """Clear the expression."""
+        logger.debug("Clearing expression")
+        self.expression_var.set("")
+
+    def run(self) -> None:
+        """Start Tkinter main loop."""
+        self.root.mainloop()
+
+
+def main() -> None:
+    """Entry point for command-line and GUI usage."""
+    parser = argparse.ArgumentParser(description="Dan graphical calculator")
+    parser.add_argument("--expression", help="Evaluate expression without GUI")
+    args = parser.parse_args()
+
+    if args.expression:
+        try:
+            result = safe_eval(args.expression)
+            print(result)
+            logger.info("CLI evaluation: %s = %s", args.expression, result)
+        except Exception as exc:  # pragma: no cover - CLI feedback
+            logger.exception("CLI evaluation error for %s", args.expression)
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        app = CalculatorApp()
+        app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup_dan_environment.bat
+++ b/setup_dan_environment.bat
@@ -1,0 +1,15 @@
+@echo off
+REM setup_dan_environment.bat
+REM Mini-readme: Creates a Python virtual environment for Dan calculator on Windows.
+REM Usage: setup_dan_environment.bat
+REM Structure:
+REM  1. Define environment directory
+REM  2. Create virtual environment
+REM  3. Activate environment
+REM  4. Install dependencies (currently none)
+SET ENV_DIR=.venv
+python -m venv %ENV_DIR%
+CALL %ENV_DIR%\Scripts\activate
+python -m pip install --upgrade pip
+REM No external dependencies required
+ECHO Virtual environment created in %ENV_DIR%. Activate with: CALL %ENV_DIR%\Scripts\activate

--- a/setup_dan_environment.sh
+++ b/setup_dan_environment.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# setup_dan_environment.sh
+# Mini-readme: Creates a Python virtual environment for Dan calculator.
+# Usage: bash setup_dan_environment.sh
+# Structure:
+#  1. Define environment directory
+#  2. Create virtual environment
+#  3. Activate environment
+#  4. Install dependencies (currently none)
+#  5. Inform user
+set -euo pipefail
+ENV_DIR=".venv"
+python3 -m venv "$ENV_DIR"
+# shellcheck disable=SC1091
+source "$ENV_DIR/bin/activate"
+python -m pip install --upgrade pip
+# No external dependencies required
+echo "Virtual environment created in $ENV_DIR. Activate with: source $ENV_DIR/bin/activate"


### PR DESCRIPTION
## Summary
- build "Dan" green-themed Tkinter calculator with safe AST-based evaluation and logging
- add cross-platform setup scripts for virtual environment creation
- document usage and setup steps for Linux, macOS, Raspberry Pi, and Windows

## Testing
- `python -m py_compile dan_graphical_calculator.py`
- `bash -n setup_dan_environment.sh`
- `cmd.exe /c setup_dan_environment.bat` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8997442808328b8f009a8f4a0a909